### PR TITLE
Fixed lua_hash return value handling in lj_str_new

### DIFF
--- a/src/lj_str.c
+++ b/src/lj_str.c
@@ -180,7 +180,11 @@ GCstr *lj_str_new(lua_State *L, const char *str, size_t lenx)
   g = G(L);
   /* Compute string hash. Constants taken from lookup3 hash by Bob Jenkins. */
   MSize h = lua_hash(str, len);
-  if (h == 0)
+  /*
+  ** Calculated hash can equal zero not only for an empty string. Thus within
+  ** condition below we also need to get a string length into consideration.
+  **/
+  if (len == 0 && h == 0)
     return &g->strempty;
   /* Check if the string has already been interned. */
   o = gcref(g->strhash[h & g->strmask]);


### PR DESCRIPTION
Previous implementation of lj_str_new assumes zero value returned from
lua_hash as hash value of an empty string, however there are also
non-empty strings with zero hash value.