### PR TITLE
bugfix: fixed assertion failure "lj_record.c:92: rec_check_slots

### DIFF
--- a/src/lj_record.c
+++ b/src/lj_record.c
@@ -1858,6 +1858,8 @@ static void rec_varg(jit_State *J, BCReg dst, ptrdiff_t nresults)
       lj_trace_err_info(J, LJ_TRERR_NYIBC);
     }
   }
+  if (J->baseslot + J->maxslot >= LJ_MAX_JSLOTS)
+    lj_trace_err(J, LJ_TRERR_STACKOV);
 }
 
 /* -- Record allocations -------------------------------------------------- */


### PR DESCRIPTION
bugfix: fixed assertion failure "lj_record.c:92: rec_check_slots: Assertion `nslots <= 250' failed" found by stressing our edgelang compiler.

Cherry-pick 1951d9a4065cb84738d9077c1a77475cc81b4a6d

Need for https://github.com/tarantool/tarantool/issues/4053