### PR TITLE
build: fix build with disabled lua jit

### DIFF
--- a/src/lj_memprof.c
+++ b/src/lj_memprof.c
@@ -13,6 +13,7 @@
 #include <errno.h>
 
 #include "lj_arch.h"
+#include "lj_jit.h"
 #include "lj_memprof.h"
 
 #if LJ_HASMEMPROF


### PR DESCRIPTION
Previously it was impossible to build Lua JIT with disabled JIT option (`-DLUAJIT_DISABLE_JIT=ON` flag) because of the missed include. Fixed.