### PR TITLE
Fix ASan build on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,8 +461,8 @@ set(LUAJIT_TEST_INIT "${PROJECT_SOURCE_DIR}/test/luajit-test-init.lua" CACHE STR
 # directory root (hence, in this CMakeLists.txt).
 if(LUAJIT_USE_TEST)
   enable_testing()
+  add_subdirectory(test)
 endif()
-add_subdirectory(test)
 
 # --- Benchmarks source tree ---------------------------------------------------
 

--- a/test/LuaJIT-tests/CMakeLists.txt
+++ b/test/LuaJIT-tests/CMakeLists.txt
@@ -24,21 +24,24 @@ if(LUAJIT_USE_ASAN)
   # "((__interception::real___cxa_throw)) != (0)" (0x0, 0x0)
   # This is a workaround suggested at
   # https://github.com/google/sanitizers/issues/934.
-  LibRealPath(LIB_STDCPP libstdc++.so)
-  # XXX: GCC requires both. Clang requires only libstdc++.
-  # Be aware, ASAN runtime in Clang on Linux was offered only in
-  # the form of a library with differ name from libasan.so (e.g.
-  # libclang_rt.asan-x86_64.a).
-  # See also:
-  # https://github.com/google/sanitizers/wiki/AddressSanitizerAsDso.
-  if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    LibRealPath(LIB_ASAN libasan.so)
-    # XXX: The items of the list in LD_PRELOAD can be separated
-    # by spaces or colons, and there is no support for escaping
-    # either separator, see ld.so(8).
-    list(APPEND LUAJIT_TESTS_ENV LD_PRELOAD=${LIB_ASAN}:${LIB_STDCPP})
-  else()
-    list(APPEND LUAJIT_TESTS_ENV LD_PRELOAD=${LIB_STDCPP})
+  # FreeBSD uses libc++ and doesn't need this workaround.
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    LibRealPath(LIB_STDCPP libstdc++.so)
+    # XXX: GCC requires both. Clang requires only libstdc++.
+    # Be aware, ASAN runtime in Clang on Linux was offered only in
+    # the form of a library with differ name from libasan.so (e.g.
+    # libclang_rt.asan-x86_64.a).
+    # See also:
+    # https://github.com/google/sanitizers/wiki/AddressSanitizerAsDso.
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+      LibRealPath(LIB_ASAN libasan.so)
+      # XXX: The items of the list in LD_PRELOAD can be separated
+      # by spaces or colons, and there is no support for escaping
+      # either separator, see ld.so(8).
+      list(APPEND LUAJIT_TESTS_ENV LD_PRELOAD=${LIB_ASAN}:${LIB_STDCPP})
+    else()
+      list(APPEND LUAJIT_TESTS_ENV LD_PRELOAD=${LIB_STDCPP})
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
This MR fixes LuaJIT ASan-instrumented builds on FreeBSD, which currently fail with:

>   CMake Error at test/cmake/LibRealPath.cmake:27 (message):
>     Library 'libstdc++.so' is not found
  
Two issues combine to cause this failure:

1. `add_subdirectory(test)` is called unconditionally in the root `CMakeLists.txt`, even when `LUAJIT_USE_TEST=OFF`.
This means test configuration  runs regardless of whether tests are needed.
3. When `LUAJIT_USE_ASAN=ON`, `test/LuaJIT-tests/CMakeLists.txt` searches for `libstdc++.so` to set up an `LD_PRELOAD` workaround for google/sanitizers#934. This workaround is GCC-specific, but FreeBSD uses clang with `libc++`, not `libstdc++`.

Verified on FreeBSD 15.0 with clang 19:
```
mkdir build && cd build
cmake .. -DLUAJIT_USE_ASAN=ON
make -j$(sysctl -n hw.ncpu)
ASAN_OPTIONS=verbosity=1 ./src/luajit -v 2>&1 | grep -i AddressSanitizer
```
